### PR TITLE
Feature/c make improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,19 +30,7 @@ endif()
 #Postfix for debug libraries so they can live alongside release libraries
 set(CMAKE_DEBUG_POSTFIX ".debug" CACHE STRING "Debug file extension")
 
-message("CMAKE_Fortran_FLAGS_DEBUG is ${CMAKE_Fortran_FLAGS_DEBUG}")
-message("CMAKE_Fortran_FLAGS_RELEASE is ${CMAKE_Fortran_FLAGS_RELEASE}")
-message("CMAKE_Fortran_FLAGS_RELWITHDEBINFO is ${CMAKE_Fortran_FLAGS_RELWITHDEBINFO}")
-message("CMAKE_Fortran_FLAGS_MINSIZEREL is ${CMAKE_Fortran_FLAGS_MINSIZEREL}")
-
-message("CMAKE_C_FLAGS_DEBUG is ${CMAKE_C_FLAGS_DEBUG}")
-message("CMAKE_C_FLAGS_RELEASE is ${CMAKE_C_FLAGS_RELEASE}")
-message("CMAKE_C_FLAGS_RELWITHDEBINFO is ${CMAKE_C_FLAGS_RELWITHDEBINFO}")
-message("CMAKE_C_FLAGS_MINSIZEREL is ${CMAKE_C_FLAGS_MINSIZEREL}")
-
-
 ### Compilation flags
-
 ## Package compiler flags
 #Public flags are necessary to build the library and to build code that links against the library
 #Private flags are necessary only when building the library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,36 +22,26 @@ message(STATUS "Option: BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
 message(STATUS "Option: OPT_IPO: ${OPT_IPO}")
 
 #Set default build type to Release if not specified
-if(NOT CMAKE_CONFIGURATION_TYPES)
-  if(NOT CMAKE_BUILD_TYPE)
+if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
     message(STATUS "Setting default build type to 'Release'.  Set CMAKE_BUILD_TYPE variable to change build types.")
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY VALUE "Release")
-  endif()
 endif()
 
 #Postfix for debug libraries so they can live alongside release libraries
 set(CMAKE_DEBUG_POSTFIX ".debug" CACHE STRING "Debug file extension")
 
-### Compilation flags
-## General compiler flags
-#GNU compiler flags - debug
-add_compile_options($<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:Fortran>,$<Fortran_COMPILER_ID:GNU>>:-O0>
-                    $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:Fortran>,$<Fortran_COMPILER_ID:GNU>>:-W>
-                    $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:Fortran>,$<Fortran_COMPILER_ID:GNU>>:-Wall>
-                    $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:Fortran>,$<Fortran_COMPILER_ID:GNU>>:-Wextra>
-                    $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:Fortran>,$<Fortran_COMPILER_ID:GNU>>:-Wno-tabs>
-                    $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:Fortran>,$<Fortran_COMPILER_ID:GNU>>:-Wno-unused-parameter>)
-add_compile_options($<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:C>,$<C_COMPILER_ID:GNU>>:-O0>
-                    $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:C>,$<C_COMPILER_ID:GNU>>:-W>
-                    $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:C>,$<C_COMPILER_ID:GNU>>:-Wall>
-                    $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:C>,$<C_COMPILER_ID:GNU>>:-Wextra>)
+message("CMAKE_Fortran_FLAGS_DEBUG is ${CMAKE_Fortran_FLAGS_DEBUG}")
+message("CMAKE_Fortran_FLAGS_RELEASE is ${CMAKE_Fortran_FLAGS_RELEASE}")
+message("CMAKE_Fortran_FLAGS_RELWITHDEBINFO is ${CMAKE_Fortran_FLAGS_RELWITHDEBINFO}")
+message("CMAKE_Fortran_FLAGS_MINSIZEREL is ${CMAKE_Fortran_FLAGS_MINSIZEREL}")
 
-#INTEL compiler flags - debug
-add_compile_options($<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:Fortran>,$<Fortran_COMPILER_ID:Intel>>:-W1>
-                    $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:Fortran>,$<Fortran_COMPILER_ID:Intel>>:-traceback>
-                    $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:Fortran>,$<Fortran_COMPILER_ID:Intel>>:-CB>
-                    $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:Fortran>,$<Fortran_COMPILER_ID:Intel>>:-ftrapuv>)
-add_compile_options($<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:C>,$<C_COMPILER_ID:Intel>>:-W1>)
+message("CMAKE_C_FLAGS_DEBUG is ${CMAKE_C_FLAGS_DEBUG}")
+message("CMAKE_C_FLAGS_RELEASE is ${CMAKE_C_FLAGS_RELEASE}")
+message("CMAKE_C_FLAGS_RELWITHDEBINFO is ${CMAKE_C_FLAGS_RELWITHDEBINFO}")
+message("CMAKE_C_FLAGS_MINSIZEREL is ${CMAKE_C_FLAGS_MINSIZEREL}")
+
+
+### Compilation flags
 
 ## Package compiler flags
 #Public flags are necessary to build the library and to build code that links against the library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,19 +30,39 @@ if(NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 #Postfix for debug libraries so they can live alongside release libraries
-set(CMAKE_DEBUG_POSTFIX "_d")
+set(CMAKE_DEBUG_POSTFIX ".debug" CACHE STRING "Debug file extension")
 
 ### Compilation flags
+## General compiler flags
+#GNU compiler flags - debug
+add_compile_options($<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:Fortran>,$<Fortran_COMPILER_ID:GNU>>:-O0>
+                    $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:Fortran>,$<Fortran_COMPILER_ID:GNU>>:-W>
+                    $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:Fortran>,$<Fortran_COMPILER_ID:GNU>>:-Wall>
+                    $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:Fortran>,$<Fortran_COMPILER_ID:GNU>>:-Wextra>
+                    $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:Fortran>,$<Fortran_COMPILER_ID:GNU>>:-Wno-tabs>
+                    $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:Fortran>,$<Fortran_COMPILER_ID:GNU>>:-Wno-unused-parameter>)
+add_compile_options($<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:C>,$<C_COMPILER_ID:GNU>>:-O0>
+                    $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:C>,$<C_COMPILER_ID:GNU>>:-W>
+                    $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:C>,$<C_COMPILER_ID:GNU>>:-Wall>
+                    $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:C>,$<C_COMPILER_ID:GNU>>:-Wextra>)
 
+#INTEL compiler flags - debug
+add_compile_options($<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:Fortran>,$<Fortran_COMPILER_ID:Intel>>:-W1>
+                    $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:Fortran>,$<Fortran_COMPILER_ID:Intel>>:-traceback>
+                    $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:Fortran>,$<Fortran_COMPILER_ID:Intel>>:-CB>
+                    $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:Fortran>,$<Fortran_COMPILER_ID:Intel>>:-ftrapuv>)
+add_compile_options($<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:C>,$<C_COMPILER_ID:Intel>>:-W1>)
+
+## Package compiler flags
 #Public flags are necessary to build the library and to build code that links against the library
-set(BUFRLIB_PUBLIC_FLAGS DYNAMIC_ALLOCATION)
-
 #Private flags are necessary only when building the library
+set(PUBLIC_FLAGS DYNAMIC_ALLOCATION)
+
 set(BUFRLIB_PRM src/bufrlib.prm)
 file(READ ${BUFRLIB_PRM} BUFRLIB_PRM_STR)
 foreach(_var IN ITEMS MAXNC MXNAF)
     if(BUFRLIB_PRM_STR MATCHES "${_var} = ([0-9]+)")
-        list(APPEND BUFRLIB_PRIVATE_FLAGS $<$<COMPILE_LANGUAGE:C>:${_var}=${CMAKE_MATCH_1}>)
+        list(APPEND PRIVATE_FLAGS $<$<COMPILE_LANGUAGE:C>:${_var}=${CMAKE_MATCH_1}>)
     else()
         message(FATAL_ERROR "Unable to parse variable ${_var} value from file: ${BUFRLIB_PRM}")
     endif()
@@ -51,14 +71,14 @@ endforeach()
 include(TestBigEndian)
 test_big_endian(IS_BIG_ENDIAN)
 if(IS_BIG_ENDIAN)
-    list(APPEND BUFRLIB_PRIVATE_FLAGS $<$<COMPILE_LANGUAGE:Fortran>:BIG_ENDIAN>)
+    list(APPEND PRIVATE_FLAGS $<$<COMPILE_LANGUAGE:Fortran>:BIG_ENDIAN>)
 else()
-    list(APPEND BUFRLIB_PRIVATE_FLAGS $<$<COMPILE_LANGUAGE:Fortran>:LITTLE_ENDIAN>)
+    list(APPEND PRIVATE_FLAGS $<$<COMPILE_LANGUAGE:Fortran>:LITTLE_ENDIAN>)
 endif()
 
 ### Global compilation properties
-set(BUFRLIB_INCLUDE_DIR bufrlib) #path relative to <prefix>/include/ to install headers/modules
-set(CMAKE_Fortran_MODULE_DIRECTORY ${BUFRLIB_INCLUDE_DIR})
+set(INCLUDE_DIR ${PROJECT_NAME}) #path relative to <prefix>/include/ to install headers/modules
+set(CMAKE_Fortran_MODULE_DIRECTORY ${INCLUDE_DIR})
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 #Enable interproceedural optimization if available
@@ -83,8 +103,8 @@ file(GLOB F_SRC src/modv*.F src/moda*.F src/*.f src/*.F) #Order of compilation i
 
 #Use a common object library for building shared and static targets
 add_library(${PROJECT_NAME}_objects OBJECT ${C_SRC} ${F_SRC})
-target_compile_definitions(${PROJECT_NAME}_objects PUBLIC ${BUFRLIB_PUBLIC_FLAGS} 
-                                                   PRIVATE ${BUFRLIB_PRIVATE_FLAGS})
+target_compile_definitions(${PROJECT_NAME}_objects PUBLIC ${PUBLIC_FLAGS} 
+                                                   PRIVATE ${PRIVATE_FLAGS})
 
 #Add static lib target
 if(BUILD_STATIC_LIBS)
@@ -102,11 +122,13 @@ endif()
 set_target_properties(${LIB_TARGETS} PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
 
 ### Install
-install(TARGETS ${LIB_TARGETS} EXPORT ${PROJECT_NAME}Exports 
-        INCLUDES DESTINATION include/${BUFRLIB_INCLUDE_DIR})
-install(FILES ${C_HDRS} DESTINATION include/${BUFRLIB_INCLUDE_DIR})
-install(DIRECTORY ${CMAKE_BINARY_DIR}/${BUFRLIB_INCLUDE_DIR}/
-        DESTINATION include/${BUFRLIB_INCLUDE_DIR})
+install(TARGETS ${LIB_TARGETS} EXPORT ${PROJECT_NAME}Exports
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+        INCLUDES DESTINATION include/${INCLUDE_DIR})
+install(FILES ${C_HDRS} DESTINATION include/${INCLUDE_DIR})
+install(DIRECTORY ${CMAKE_BINARY_DIR}/${INCLUDE_DIR}/
+        DESTINATION include/${INCLUDE_DIR})
 
 ### Package config
 include(CMakePackageConfigHelpers)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,23 @@ for each build type, and build and install to the same prefix, or using the `bui
 ./tools/build.sh <install-prefix> -DBUILD_STATIC_LIBS=1 -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Debug
 ```
 
+### Setting compilers and flags
+
+The compilers and flags used can be controled by setting normal environment variables before the CMake configure
+step.
+ * `FC` - Fortran compiler
+ * `CC` - C compiler
+ * `FFLAGS` - Fortran compiler flags
+ * `CFLAGS` - C compiler flags
+ * `LDFLAGS` - Linker flags
+
+### Debugging compilation/linking errors
+
+To see the exact command line arguments, the CMake generated Makefile will respect the `VERBOSE` environment variable:
+```
+cd _build && VERBOSE=1 make
+```
+
 ## Using the BUFRLIB CMake package in CMakeLists.txt
 
 ```

--- a/README.md
+++ b/README.md
@@ -31,12 +31,19 @@ via the `-D<var>=<val>` syntax:
 This package can build both static and shared libraries simultaneously.  At least one of `BUILD_STATIC_LIBS` or `BUILD_SHARED_LIBS` must be set.  If neither is set,
 `BUILD_STATIC_LIBS` will be used.
 
-### CMake Package Config
+### CMake package config
 
 This package installs a modern [CMake package config file](https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#config-file-packages)
 which provides [imported interface targets](https://cmake.org/cmake/help/latest/command/add_library.html#interface-libraries) using
 CMake namespaces.
 
+#### Components
+
+The bufrlib package config file can identify the following components through `COMPONENTS` or `REQUIRED COMPONENTS` keywords to the 
+`find_package()` command.
+ * `SHARED` - Find shared libraries
+ * `STATIC` - Find shared libraries
+ 
 #### Provided imported interface libraries
 
  * `bufrlib::bufrlib_static` - Static libraries if available
@@ -49,7 +56,7 @@ CMake namespaces.
  * `bufrlib_SHARED_LIBRARIES` - Set to `bufrlib::bufrlib_shared` if available.
  * `bufrlib_BUILD_TYPES` - List of `CMAKE_BUILD_TYPE`s available.
 
-### CMake Build types
+### CMake build types
 
 This package has the capability to install *Debug* and *Release* versions of both static and shared
 libraries so that they can coexist under the same install prefix.  Using the generated CMake package config file, a downstream package
@@ -59,7 +66,7 @@ property of the [imported interface targets](https://cmake.org/cmake/help/latest
 version of this library.
 
 To build and install shared and static versions of *Debug* and *Release* build types to the
-same install prefix, the build procedure can be repeated for each build-type:
+same install prefix, the build procedure can be repeated for each build-type.
 ```
 ./tools/build.sh <install-prefix> -DBUILD_STATIC_LIBS=1 -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release
 ./tools/build.sh <install-prefix> -DBUILD_STATIC_LIBS=1 -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Debug
@@ -87,23 +94,19 @@ The following environment variables are of general use for configuring custom bu
    * Sets: `CMAKE_Fortran_COMPILER`
  * [`CC`](https://cmake.org/cmake/help/latest/envvar/CC.html) - C compiler (full path to executable or name of executable on PATH).
    * Sets: `CMAKE_C_COMPILER`
- * [`CXX`](https://cmake.org/cmake/help/latest/envvar/CXX.html) - C++ compiler (full path to executable or name of executable on PATH). 
-   * Sets: `CMAKE_CXX_COMPILER`
  * [`FFLAGS`](https://cmake.org/cmake/help/latest/envvar/FFLAGS.html) - Fortran compiler flags 
    * Sets: `CMAKE_Fortran_FLAGS`
  * [`CFLAGS`](https://cmake.org/cmake/help/latest/envvar/CFLAGS.html) - C compiler flags 
    * Sets: `CMAKE_C_FLAGS`
- * [`CXXFLAGS`](https://cmake.org/cmake/help/latest/envvar/CXXFLAGS.html) - C++ compile flags 
-   * Sets: `CMAKE_CXX_FLAGS`
  * [`LDFLAGS`](https://cmake.org/cmake/help/latest/envvar/LDFLAGS.html) - Universal linker flags.  Common flags for all linker operations.
    * Sets: `CMAKE_EXE_LINKER_FLAGS`, `CMAKE_SHARED_LINKER_FLAGS`, `CMAKE_STATIC_LINKER_FLAGS`, and `CMAKE_MODULE_LINKER_FLAGS`
 
-#### CMake Cache variables
+#### CMake cache variables
 Finer-grained control over the compilers and flags used can be achieved using CMake cache variables.  These variables can be configured directly by using the `-D<var>=<val>` arguments to the `cmake` command
 when generating a new build directory.  After the initial build-system generation, cache variables
 can be viewed and modified with the [CMake GUI](https://cmake.org/cmake/help/latest/manual/cmake-gui.1.html), which must be given the path to the build directory as input, *e.g.*:
 ```
-$ cd <build-dir> && cmake-gui . &
+cd <build-dir> && cmake-gui . &
 ```
 
 The following CMake cache variables are useful for controlling the compilation and linking steps.  These variables define the base set of flags used for compilation and linking processes, but targets
@@ -113,14 +116,11 @@ Optional or system dependent flags should be set directly via these CMake cache 
  * **Compilers**
    * [`CMAKE_Fortran_COMPILER`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER.html) - Full path to the Fortran compiler.
    * [`CMAKE_C_COMPILER`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER.html) - Full path to the C compiler.
-   * [`CMAKE_CXX_COMPILER`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER.html) - Full path to the C++ compiler.
  * **Compiler flags**
    * [`CMAKE_Fortran_FLAGS`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS.html) - Common set of universal Fortran compiler flags.
    * [`CMAKE_Fortran_FLAGS_<BUILD-TYPE>`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS_CONFIG.html) - Fortran compiler flags specific to each CMake build type.
    * [`CMAKE_C_FLAGS`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS.html) - Common set of universal C compiler flags.
    * [`CMAKE_C_FLAGS_<BUILD-TYPE>`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS_CONFIG.html)  - C compiler flags specific to each CMake build type.
-   * [`CMAKE_CX_FLAGS`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS.html) - Common set of universal C++ compiler flags.
-   * [`CMAKE_CXX_FLAGS_<BUILD-TYPE>`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS_CONFIG.html)  - C++ compiler flags specific to each CMake build type.
  * **Linker flags** 
    * [`CMAKE_EXE_LINKER_FLAGS`](https://cmake.org/cmake/help/latest/variable/CMAKE_EXE_LINKER_FLAGS.html) - Common set of linker flags used when creating an executable.
    * [`CMAKE_EXE_LINKER_FLAGS_<BUILD-TYPE>`](https://cmake.org/cmake/help/latest/variable/CMAKE_EXE_LINKER_FLAGS_CONFIG.html) - Linking flags for executables specific to each CMake build type.
@@ -140,22 +140,30 @@ The default build types and thier GCC flags are:
  * `RelWithDebInfo` - Optimized release version with debugging info [GCC: `-O2 -g -DNDEBUG`]
 ### Debugging compilation/linking errors
 
-To see the exact command line invocations CMake uses to build the project, set the [`VERBOSE`](https://cmake.org/cmake/help/latest/envvar/VERBOSE.html) environment variable:
+To see the exact command line invocations CMake uses to build the project, set the [`VERBOSE`](https://cmake.org/cmake/help/latest/envvar/VERBOSE.html) environment variable.
 ```
-$ cd <build-dir> && VERBOSE=1 make
+cd <build-dir> && VERBOSE=1 make
 ```
 
 ## Using the BUFRLIB package in CMake projects.
-The CMake package config file provided by this CMake build system will allow downstream libraries
-to find this library easily via the [`find_package()`](https://cmake.org/cmake/help/latest/command/find_package.html) command.  When linking a target against this library, we recommend using
-the imported interface targets provided by the package config file as arguments to the [`target_link_libraries()`](https://cmake.org/cmake/help/latest/command/target_link_libraries.html) command.  Using
+The CMake package config file provided will allow downstream libraries
+to find this library via the [`find_package()`](https://cmake.org/cmake/help/latest/command/find_package.html) command.  When linking a target against this library, we recommend using
+the provided *imported interface targets* as arguments to the [`target_link_libraries()`](https://cmake.org/cmake/help/latest/command/target_link_libraries.html) command.  Using
 the imported targets will cause all transitive dependencies as well as public linking and compiling flags
 and even library and include directories to be automatically added to your target's compilation and linking
-phases as appropriate.  For example, in the dependent project's `CMakeLists.txt`:
-```
-find_package(bufrlib REQUIRED)
-target_link_libraries(${MY_STATIC_TARGET} PRIVATE bufrlib::bufrlib_static)
-...
-target_link_libraries(${MY_SHARED_TARGET} PUBLIC bufrlib::bufrlib_shared)
+phases as appropriate.
 
+### Example useage
+
+ * Linking against the static libraries, in a dependent project's `CMakeLists.txt`:
 ```
+find_package(bufrlib REQUIRED COMPONENTS STATIC)
+target_link_libraries(${MY_STATIC_TARGET} <PUBLIC|PRIVATE|INTERFACE> bufrlib::bufrlib_static)
+```
+
+ * Linking against the shared libraries, in a dependent project's `CMakeLists.txt`:
+```
+find_package(bufrlib REQUIRED COMPONENTS SHARED)
+target_link_libraries(${MY_SHARED_TARGET} <PUBLIC|PRIVATE|INTERFACE> bufrlib::bufrlib_shared)
+```
+As described in the [`target_link_libraries()` documentation](https://cmake.org/cmake/help/latest/command/target_link_libraries.html#libraries-for-a-target-and-or-its-dependents), the choice of `PUBLIC`, `PRIVATE`, or `INTERFACE` visibility will depend on the requirements of the target library and it's own link interface as required by further downstream dependencies.

--- a/README.md
+++ b/README.md
@@ -80,16 +80,9 @@ The compiler executables as well as the compilation and linking flags used in th
 
 #### Environment variables
 Certain environment variables are respected by CMake when initially generating a build system in a
-new build directory.  Each environment variable will contribute its setting to the appropriate
-CMake cache variable(s).   This is generally done by appending and environment variables will not overwrite default 
-settings for the CMake cache variables.
+new build directory.  Each environment variable will append its value onto the default values of the appropriate
+CMake cache variable(s).  To completely override any CMake defualt values for compiler flags, use the appropriate CMake cache variables instead.
 
-Environment variables generally only have an effect when creating a new build
-directory for the first time.  Once CMake has generated the build system in a directory, subsequent re-generation
-of the build system using `cmake` on the same directory will not take into account any changes to
-environment variables because their effect has already been stored in the appropriate CMake cache variable.
-
-The following environment variables are of general use for configuring custom builds
  * [`FC`](https://cmake.org/cmake/help/latest/envvar/FC.html) - Fortran compiler (full path to executable or name of executable on PATH).
    * Sets: `CMAKE_Fortran_COMPILER`
  * [`CC`](https://cmake.org/cmake/help/latest/envvar/CC.html) - C compiler (full path to executable or name of executable on PATH).
@@ -100,6 +93,11 @@ The following environment variables are of general use for configuring custom bu
    * Sets: `CMAKE_C_FLAGS`
  * [`LDFLAGS`](https://cmake.org/cmake/help/latest/envvar/LDFLAGS.html) - Universal linker flags.  Common flags for all linker operations.
    * Sets: `CMAKE_EXE_LINKER_FLAGS`, `CMAKE_SHARED_LINKER_FLAGS`, `CMAKE_STATIC_LINKER_FLAGS`, and `CMAKE_MODULE_LINKER_FLAGS`
+
+Environment variables  only have an effect when creating a new build
+directory for the first time.  Once CMake has generated the build system in a directory, subsequent re-generation
+of the build system using `cmake` on the same directory will not take into account any changes to
+environment variables because their effect has already been stored in the appropriate CMake cache variable.
 
 #### CMake cache variables
 Finer-grained control over the compilers and flags used can be achieved using CMake cache variables.  These variables can be configured directly by using the `-D<var>=<val>` arguments to the `cmake` command
@@ -112,7 +110,7 @@ cd <build-dir> && cmake-gui . &
 The following CMake cache variables are useful for controlling the compilation and linking steps.  These variables define the base set of flags used for compilation and linking processes, but targets
 may define additional flags which are appended to the list of flags to be used.  For this reason, the CMake targets
 specified in this project only define flags that are strictly necessary for compilation and linking.
-Optional or system dependent flags should be set directly via these CMake cache variables:
+Optional or system-dependent flags should be set directly via these CMake cache variables:
  * **Compilers**
    * [`CMAKE_Fortran_COMPILER`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER.html) - Full path to the Fortran compiler.
    * [`CMAKE_C_COMPILER`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER.html) - Full path to the C compiler.

--- a/README.md
+++ b/README.md
@@ -1,31 +1,34 @@
-# bufrlib
+# NCEP BUFRLIB
 
-This is a CMake enabled fork of NCEP BUFRLIB software, which is
-described in detail at https://www.emc.ncep.noaa.gov/?branch=BUFRLIB
-and whose usage is governed by the terms and conditions of the disclaimer
-https://www.weather.gov/disclaimer.
+This is a copy of the public domain NCEP BUFRLIB software with a modern CMake build system.  This repository
+will track the most recent release of NCEP BUFRLIB, applying build-system related modifications only.
+ * Current upstream version tracked: [**11.3.0**](https://www.emc.ncep.noaa.gov/BUFRLIB/docs/versions/#v11.3.0)
+ * [NCEP BUFRLIB detailed package description](https://www.emc.ncep.noaa.gov/?branch=BUFRLIB)
+ * Distributed under the terms and conditions of the [disclaimer](https://www.weather.gov/disclaimer).
 
 ## Install
+The [CMake build system](https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html) is used to configure, build, and install this library in shared and static
+variants.  It is easily configurable enabling support for a wide range of computing environments and operating systems.
 
  * Manual installation
 ```
-cmake -H. -B_build -DCMAKE_INSTALL_PREFIX=<prefix> -DCMAKE_BUILD_TYPE=Release
+cmake -H. -B_build -DCMAKE_INSTALL_PREFIX=<prefix> -DCMAKE_BUILD_TYPE=Release <additional-cmake-args>
 cd _build && make -j<num-procs> install
 ```
  * Automatic install script
 ```
-./tools/build.sh <install-prefix> <optional-cmake-args>
+./tools/build.sh <install-prefix> <additional-cmake-args>
 ```
 
 ### CMake options
 
-The following CMake variables control the build:
+The following CMake cache variables control the build.  They can be set as arguments to the cmake executable
+via the `-D<var>=<val>` syntax:
  * `BUILD_STATIC_LIBS` - Build static libraries. [default=ON]
  * `BUILD_SHARED_LIBS` - Build shared libraries. [default=OFF]
  * `OPT_IPO` - Enable [interprocedural optimization](https://en.wikipedia.org/wiki/Interprocedural_optimization) if available. [default=ON] 
 
-This package can build both static and shared libraries simultaneously, as specified by the CMake
-options.  At least one of `BUILD_STATIC_LIBS` or `BUILD_SHARED_LIBS` must be set.  If neither is set,
+This package can build both static and shared libraries simultaneously.  At least one of `BUILD_STATIC_LIBS` or `BUILD_SHARED_LIBS` must be set.  If neither is set,
 `BUILD_STATIC_LIBS` will be used.
 
 ### CMake Package Config
@@ -34,12 +37,12 @@ This package installs a modern [CMake package config file](https://cmake.org/cma
 which provides [imported interface targets](https://cmake.org/cmake/help/latest/command/add_library.html#interface-libraries) using
 CMake namespaces.
 
-#### Available imported interface libraries
+#### Provided imported interface libraries
 
- * `bufrlib::bufrlib_static` - static libraries if available
- * `bufrlib::bufrlib_shared` - shared libraries if available
+ * `bufrlib::bufrlib_static` - Static libraries if available
+ * `bufrlib::bufrlib_shared` - Shared libraries if available
 
-#### Package config variables provided
+#### Provided CMake variables
 
  * `bufrlib_LIBRARIES` - Defaults to `bufrlib::bufrlib_static` if available, or `bufrlib::bufrlib_shared` otherwise
  * `bufrlib_STATIC_LIBRARIES` - Set to `bufrlib::bufrlib_static` if available.
@@ -48,14 +51,15 @@ CMake namespaces.
 
 ### CMake Build types
 
-This package has the capability to install debug and release versions of both static and shared
-libraries so that they can coexist in the same install prefix.  The CMake package config file provides
-targets for both debug and release versions if both are installed to the same prefix, via the
+This package has the capability to install *Debug* and *Release* versions of both static and shared
+libraries so that they can coexist under the same install prefix.  Using the generated CMake package config file, a downstream package
+will use the 
 [`IMPORTED_CONFIGURATIONS`](https://cmake.org/cmake/help/latest/prop_tgt/IMPORTED_CONFIGURATIONS.html)
-property of imported interface targets.
+property of the [imported interface targets](https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#interface-libraries) to link to the correct *Debug* or *Release*
+version of this library.
 
-For example, to build shared and static versions of debug and release build types, one can invoke CMake
-for each build type, and build and install to the same prefix, or using the `build.sh` script:
+To build and install shared and static versions of *Debug* and *Release* build types to the
+same install prefix, the build procedure can be repeated for each build-type:
 ```
 ./tools/build.sh <install-prefix> -DBUILD_STATIC_LIBS=1 -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release
 ./tools/build.sh <install-prefix> -DBUILD_STATIC_LIBS=1 -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Debug
@@ -63,24 +67,95 @@ for each build type, and build and install to the same prefix, or using the `bui
 
 ### Setting compilers and flags
 
-The compilers and flags used can be controled by setting normal environment variables before the CMake configure
-step.
- * `FC` - Fortran compiler
- * `CC` - C compiler
- * `FFLAGS` - Fortran compiler flags
- * `CFLAGS` - C compiler flags
- * `LDFLAGS` - Linker flags
+The compiler executables as well as the compilation and linking flags used in the build can be controlled via:
+ 1) Setting normal **environment variables** before the CMake configure step, or by 
+ 2) Setting **CMake cache variables** on the `cmake` command line or through the [CMake GUI](https://cmake.org/cmake/help/latest/manual/cmake-gui.1.html).
 
+#### Environment variables
+Certain environment variables are respected by CMake when initially generating a build system in a
+new build directory.  Each environment variable will contribute its setting to the appropriate
+CMake cache variable(s).   This is generally done by appending and environment variables will not overwrite default 
+settings for the CMake cache variables.
+
+Environment variables generally only have an effect when creating a new build
+directory for the first time.  Once CMake has generated the build system in a directory, subsequent re-generation
+of the build system using `cmake` on the same directory will not take into account any changes to
+environment variables because their effect has already been stored in the appropriate CMake cache variable.
+
+The following environment variables are of general use for configuring custom builds
+ * [`FC`](https://cmake.org/cmake/help/latest/envvar/FC.html) - Fortran compiler (full path to executable or name of executable on PATH).
+   * Sets: `CMAKE_Fortran_COMPILER`
+ * [`CC`](https://cmake.org/cmake/help/latest/envvar/CC.html) - C compiler (full path to executable or name of executable on PATH).
+   * Sets: `CMAKE_C_COMPILER`
+ * [`CXX`](https://cmake.org/cmake/help/latest/envvar/CXX.html) - C++ compiler (full path to executable or name of executable on PATH). 
+   * Sets: `CMAKE_CXX_COMPILER`
+ * [`FFLAGS`](https://cmake.org/cmake/help/latest/envvar/FFLAGS.html) - Fortran compiler flags 
+   * Sets: `CMAKE_Fortran_FLAGS`
+ * [`CFLAGS`](https://cmake.org/cmake/help/latest/envvar/CFLAGS.html) - C compiler flags 
+   * Sets: `CMAKE_C_FLAGS`
+ * [`CXXFLAGS`](https://cmake.org/cmake/help/latest/envvar/CXXFLAGS.html) - C++ compile flags 
+   * Sets: `CMAKE_CXX_FLAGS`
+ * [`LDFLAGS`](https://cmake.org/cmake/help/latest/envvar/LDFLAGS.html) - Universal linker flags.  Common flags for all linker operations.
+   * Sets: `CMAKE_EXE_LINKER_FLAGS`, `CMAKE_SHARED_LINKER_FLAGS`, `CMAKE_STATIC_LINKER_FLAGS`, and `CMAKE_MODULE_LINKER_FLAGS`
+
+#### CMake Cache variables
+Finer-grained control over the compilers and flags used can be achieved using CMake cache variables.  These variables can be configured directly by using the `-D<var>=<val>` arguments to the `cmake` command
+when generating a new build directory.  After the initial build-system generation, cache variables
+can be viewed and modified with the [CMake GUI](https://cmake.org/cmake/help/latest/manual/cmake-gui.1.html), which must be given the path to the build directory as input, *e.g.*:
+```
+$ cd <build-dir> && cmake-gui . &
+```
+
+The following CMake cache variables are useful for controlling the compilation and linking steps.  These variables define the base set of flags used for compilation and linking processes, but targets
+may define additional flags which are appended to the list of flags to be used.  For this reason, the CMake targets
+specified in this project only define flags that are strictly necessary for compilation and linking.
+Optional or system dependent flags should be set directly via these CMake cache variables:
+ * **Compilers**
+   * [`CMAKE_Fortran_COMPILER`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER.html) - Full path to the Fortran compiler.
+   * [`CMAKE_C_COMPILER`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER.html) - Full path to the C compiler.
+   * [`CMAKE_CXX_COMPILER`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER.html) - Full path to the C++ compiler.
+ * **Compiler flags**
+   * [`CMAKE_Fortran_FLAGS`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS.html) - Common set of universal Fortran compiler flags.
+   * [`CMAKE_Fortran_FLAGS_<BUILD-TYPE>`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS_CONFIG.html) - Fortran compiler flags specific to each CMake build type.
+   * [`CMAKE_C_FLAGS`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS.html) - Common set of universal C compiler flags.
+   * [`CMAKE_C_FLAGS_<BUILD-TYPE>`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS_CONFIG.html)  - C compiler flags specific to each CMake build type.
+   * [`CMAKE_CX_FLAGS`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS.html) - Common set of universal C++ compiler flags.
+   * [`CMAKE_CXX_FLAGS_<BUILD-TYPE>`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS_CONFIG.html)  - C++ compiler flags specific to each CMake build type.
+ * **Linker flags** 
+   * [`CMAKE_EXE_LINKER_FLAGS`](https://cmake.org/cmake/help/latest/variable/CMAKE_EXE_LINKER_FLAGS.html) - Common set of linker flags used when creating an executable.
+   * [`CMAKE_EXE_LINKER_FLAGS_<BUILD-TYPE>`](https://cmake.org/cmake/help/latest/variable/CMAKE_EXE_LINKER_FLAGS_CONFIG.html) - Linking flags for executables specific to each CMake build type.
+   * [`CMAKE_SHARED_LINKER_FLAGS`](https://cmake.org/cmake/help/latest/variable/CMAKE_SHARED_LINKER_FLAGS.html) - Common set of linker flags used when creating a shared library target.
+   * [`CMAKE_SHARED_LINKER_FLAGS_<BUILD-TYPE>`](https://cmake.org/cmake/help/latest/variable/CMAKE_SHARED_LINKER_FLAGS_CONFIG.html) - Linking flags for shared libraries specific to each CMake build type.
+   * [`CMAKE_STATIC_LINKER_FLAGS`](https://cmake.org/cmake/help/latest/variable/CMAKE_STATIC_LINKER_FLAGS.html) - Common set of linker flags used when creating a static library target.
+   * [`CMAKE_STATIC_LINKER_FLAGS_<BUILD-TYPE>`](https://cmake.org/cmake/help/latest/variable/CMAKE_STATIC_LINKER_FLAGS_CONFIG.html) - Linking flags for static libraries specific to each CMake build type.
+   * [`CMAKE_MODULE_LINKER_FLAGS`](https://cmake.org/cmake/help/latest/variable/CMAKE_MODULE_LINKER_FLAGS.html) - Common set of linker flags used when creating a Fortran module target.
+   * [`CMAKE_MODULE_LINKER_FLAGS_<BUILD-TYPE>`](https://cmake.org/cmake/help/latest/variable/CMAKE_MODULE_LINKER_FLAGS_CONFIG.html) - Linking flags for Fortran modules specific to each CMake build type.
+
+For each compiler, CMake has pre-configured sets of compiler flags specified for each of the four default build types.   To override
+these default values, the appropriate CMake cache variable should be set when generating the build directory.
+The default build types and thier GCC flags are:
+ * `Release` - Release build [GCC: `-O3 -DNDEBUG`]
+ * `Debug` - Debugging build without optimization [GCC: `-g`]
+ * `MinSizeRel` - Minimum size release [GCC: `-Os -DNDEBUG`]
+ * `RelWithDebInfo` - Optimized release version with debugging info [GCC: `-O2 -g -DNDEBUG`]
 ### Debugging compilation/linking errors
 
-To see the exact command line arguments, the CMake generated Makefile will respect the `VERBOSE` environment variable:
+To see the exact command line invocations CMake uses to build the project, set the [`VERBOSE`](https://cmake.org/cmake/help/latest/envvar/VERBOSE.html) environment variable:
 ```
-cd _build && VERBOSE=1 make
+$ cd <build-dir> && VERBOSE=1 make
 ```
 
-## Using the BUFRLIB CMake package in CMakeLists.txt
-
+## Using the BUFRLIB package in CMake projects.
+The CMake package config file provided by this CMake build system will allow downstream libraries
+to find this library easily via the [`find_package()`](https://cmake.org/cmake/help/latest/command/find_package.html) command.  When linking a target against this library, we recommend using
+the imported interface targets provided by the package config file as arguments to the [`target_link_libraries()`](https://cmake.org/cmake/help/latest/command/target_link_libraries.html) command.  Using
+the imported targets will cause all transitive dependencies as well as public linking and compiling flags
+and even library and include directories to be automatically added to your target's compilation and linking
+phases as appropriate.  For example, in the dependent project's `CMakeLists.txt`:
 ```
 find_package(bufrlib REQUIRED)
-target_link_libraries(${MY_TARGET} PRIVATE bufrlib::bufrlib_static)
+target_link_libraries(${MY_STATIC_TARGET} PRIVATE bufrlib::bufrlib_static)
+...
+target_link_libraries(${MY_SHARED_TARGET} PUBLIC bufrlib::bufrlib_shared)
+
 ```

--- a/cmake/PackageConfig.cmake.in
+++ b/cmake/PackageConfig.cmake.in
@@ -1,29 +1,43 @@
 @PACKAGE_INIT@
 
 #@PROJECT_NAME@-config.cmake
-
-#Sets:
-# @PROJECT_NAME@_LIBRARIES  - set to static libs if available, shared libs otherwise
-# @PROJECT_NAME@_SHARED_LIBRARIES - shared libaries if availible
-# @PROJECT_NAME@_STATIC_LIBRARIES - static libaries if availible
-# @PROJECT_NAME@_BUILD_TYPES - build types provided
+#
+# Valid Find COMPONENTS:
+#  * SHARED - Find shared libraries.
+#  * STATIC - Find static libraries.
+#
+# Output variables set:
+#  * @PROJECT_NAME@_LIBRARIES  - set to static libs if available, shared libs otherwise
+#  * @PROJECT_NAME@_SHARED_LIBRARIES - shared libaries if availible
+#  * @PROJECT_NAME@_STATIC_LIBRARIES - static libaries if availible
+#  * @PROJECT_NAME@_BUILD_TYPES - build types provided
 #
 # Imported interface targets provided:
-#  static lib target: @PROJECT_NAME@::@PROJECT_NAME@_static
-#  shared lib target: @PROJECT_NAME@::@PROJECT_NAME@_shared
+#  * @PROJECT_NAME@::@PROJECT_NAME@_static - static library target
+#  * @PROJECT_NAME@::@PROJECT_NAME@_shared - shared library target:
 
 #Include targets file.  This will create IMPORTED target @PROJECT_NAME@
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
-set(@PROJECT_NAME@_LIBRARIES @PROJECT_NAME@::@PROJECT_NAME@_static)
 set(@PROJECT_NAME@_SHARED_LIBRARIES)
 set(@PROJECT_NAME@_STATIC_LIBRARIES)
+set(@PROJECT_NAME@_SHARED_FOUND 0)
+set(@PROJECT_NAME@_STATIC_FOUND 0)
 if(@BUILD_STATIC_LIBS@)
     set(@PROJECT_NAME@_STATIC_LIBRARIES @PROJECT_NAME@::@PROJECT_NAME@_static)
+    set(@PROJECT_NAME@_LIBRARIES @PROJECT_NAME@::@PROJECT_NAME@_static)
+    set(@PROJECT_NAME@_STATIC_FOUND 1)
     if(@BUILD_SHARED_LIBS@)
         set(@PROJECT_NAME@_SHARED_LIBRARIES @PROJECT_NAME@::@PROJECT_NAME@_shared)
+        set(@PROJECT_NAME@_SHARED_FOUND 1)
     endif()
-else()
+elseif(@BUILD_SHARED_LIBS@)
+    #Only shared libraries are build.  Set @PROJECT_NAME@_LIBRARIES to point to shared target.
     set(@PROJECT_NAME@_SHARED_LIBRARIES @PROJECT_NAME@::@PROJECT_NAME@_shared)
+    set(@PROJECT_NAME@_LIBRARIES @PROJECT_NAME@::@PROJECT_NAME@_shared)
+    set(@PROJECT_NAME@_SHARED_FOUND 1)
+else()
+    set(@PROJECT_NAME@_FOUND 0)
+    set(@PROJECT_NAME@_NOT_FOUND_MESSAGE "Neither BUILD_SHARED_LIBS nor BUILD_STATIC_LIBS was set.  Unable to find any libararies.")
 endif()
 
 get_target_property(@PROJECT_NAME@_BUILD_TYPES @PROJECT_NAME@::@PROJECT_NAME@ IMPORTED_CONFIGURATIONS)

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -7,11 +7,13 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 SOURCE_DIR=${SCRIPT_DIR}/..
 
 #Cross-platform get number of processors
-case $(uname -s) in
-    Linux*) NUM_PROCS=$(grep -c ^processor /proc/cpuinfo);;
-    Darwin*) NUM_PROCS=$(sysctl -n hw.logicalcpu);;
-    *) NUM_PROCS=1
-esac
+if [ -z $NUM_PROCS ]; then
+    case $(uname -s) in
+        Linux*) NUM_PROCS=$(grep -c ^processor /proc/cpuinfo);;
+        Darwin*) NUM_PROCS=$(sysctl -n hw.logicalcpu);;
+        *) NUM_PROCS=1
+    esac
+fi
 
 if [ -z $1 ]; then
     INSTALL_PREFIX=/usr/local
@@ -22,5 +24,5 @@ BUILD_DIR=${SOURCE_DIR}/_build
 
 set -ex
 rm -rf ${BUILD_DIR}
-cmake -H${SOURCE_DIR} -B${BUILD_DIR} -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} ${@:2}
+cmake -H${SOURCE_DIR} -B${BUILD_DIR} -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} ${@:2}
 cmake --build ${BUILD_DIR} --target install -- -j${NUM_PROCS}


### PR DESCRIPTION
Clean-up of the new CMake build system.  

I'd like this BUFRLIB CMake build system to be an example/template for similar Fortran/C/CXX packages that are still using old Makefile (or worse) style build scripts.  I prioritized making the build system as generic as possible using `${PROJECT_NAME}` wherever possible.  The README.md is very generic and should offer a useful stand-alone tutorial for users not already familiar with the CMake way of doing things.