### PR TITLE
Revert library output name to libbufr.[a|so]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 #Set common lib target properties
-set_target_properties(${LIB_TARGETS} PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
+set_target_properties(${LIB_TARGETS} PROPERTIES OUTPUT_NAME bufr)
 
 ### Install
 install(TARGETS ${LIB_TARGETS} EXPORT ${PROJECT_NAME}Exports


### PR DESCRIPTION
This was broken by the last merge.