### PR TITLE
C/Fortran interface improvements.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,12 +54,17 @@ else()
     list(APPEND PRIVATE_FLAGS $<$<COMPILE_LANGUAGE:Fortran>:LITTLE_ENDIAN>)
 endif()
 
+include(FortranCInterface)
+if(FortranCInterface_GLOBAL_FOUND AND FortranCInterface_GLOBAL_SUFFIX STREQUAL "_")
+    list(APPEND PUBLIC_FLAGS $<$<COMPILE_LANGUAGE:C>:UNDERSCORE>)
+endif()
+
 ### Global compilation properties
 set(INCLUDE_DIR ${PROJECT_NAME}) #path relative to <prefix>/include/ to install headers/modules
 set(CMAKE_Fortran_MODULE_DIRECTORY ${INCLUDE_DIR})
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-#Enable interproceedural optimization if available
+#Enable interprocedural optimization if available
 include(CheckIPOSupported)
 check_ipo_supported(RESULT _result OUTPUT _output)
 if(_result)
@@ -98,6 +103,10 @@ endif()
 
 #Set common lib target properties
 set_target_properties(${LIB_TARGETS} PROPERTIES OUTPUT_NAME bufr)
+foreach(_tgt IN LISTS LIB_TARGETS)
+    #PUBLIC target_compile_definitions are not correctly propagated from object libraries
+    target_compile_definitions(${_tgt} PUBLIC "${PUBLIC_FLAGS}")
+endforeach()
 
 ### Install
 install(TARGETS ${LIB_TARGETS} EXPORT ${PROJECT_NAME}Exports

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(BUFRLIB_PRM src/bufrlib.prm)
 file(READ ${BUFRLIB_PRM} BUFRLIB_PRM_STR)
 foreach(_var IN ITEMS MAXNC MXNAF)
     if(BUFRLIB_PRM_STR MATCHES "${_var} = ([0-9]+)")
-        list(APPEND PRIVATE_FLAGS $<$<COMPILE_LANGUAGE:C>:${_var}=${CMAKE_MATCH_1}>)
+        list(APPEND PRIVATE_FLAGS $<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:${_var}=${CMAKE_MATCH_1}>)
     else()
         message(FATAL_ERROR "Unable to parse variable ${_var} value from file: ${BUFRLIB_PRM}")
     endif()
@@ -56,7 +56,7 @@ endif()
 
 include(FortranCInterface)
 if(FortranCInterface_GLOBAL_FOUND AND FortranCInterface_GLOBAL_SUFFIX STREQUAL "_")
-    list(APPEND PUBLIC_FLAGS $<$<COMPILE_LANGUAGE:C>:UNDERSCORE>)
+    list(APPEND PUBLIC_FLAGS $<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:UNDERSCORE>)
 endif()
 
 ### Global compilation properties

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,9 @@ cmake_minimum_required( VERSION 3.9 )
 project(bufrlib VERSION 11.3 LANGUAGES C Fortran)
 
 ### Configuration options
-option(BUILD_STATIC_LIBS "Build static libarary" ON)
-option(BUILD_SHARED_LIBS "Build shared libarary" OFF)
-option(OPT_IPO "Enable interproceedural optimization if availible." ON)
+option(BUILD_STATIC_LIBS "Build static library" ON)
+option(BUILD_SHARED_LIBS "Build shared library" OFF)
+option(OPT_IPO "Enable interprocedural optimization if available." ON)
 
 #Ensure at least one of BUILD_SHARED_LIBS and BUILD_STATIC_LIBS is set
 if(NOT (BUILD_STATIC_LIBS OR BUILD_SHARED_LIBS))
@@ -70,13 +70,13 @@ check_ipo_supported(RESULT _result OUTPUT _output)
 if(_result)
     if(OPT_IPO)
         set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
-        message(STATUS "Interproceedural optimization: Enabled")
+        message(STATUS "Interprocedural optimization: Enabled")
     else()
         set(CMAKE_INTERPROCEDURAL_OPTIMIZATION OFF)
-        message(STATUS "Interproceedural optimization: Disabled")
+        message(STATUS "Interprocedural optimization: Disabled")
     endif()
 else()
-    message(STATUS "Interproceedural optimization: Not availible")
+    message(STATUS "Interprocedural optimization: Not available")
 endif()
 
 ### Define Library Targets


### PR DESCRIPTION
  * Check for C/Fortran interface useage of "_" using [`FortranCInterface`](https://cmake.org/cmake/help/latest/module/FortranCInterface.html)
  * Fix propagation of PUBLIC compile_definitions from object libraries

@srherbener Do you have some independent way of testing the C functionality?  There is obviously no testing code here, so I'm still not sure if everything is getting the right flags.  On OSX you should see something like this in the targets config module, which should be propagating the correct flags.
```
 $ grep UNDERSCORE _install/share/bufrlib/cmake/bufrlib-targets.cmake 
  INTERFACE_COMPILE_DEFINITIONS "DYNAMIC_ALLOCATION;\$<\$<COMPILE_LANGUAGE:C>:UNDERSCORE>"
```