### PR TITLE
Fix link-time-optimization warnings for downstream dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ foreach(_tgt IN LISTS LIB_TARGETS)
     #Include Fortran module output directory for build and install interfaces
     target_include_directories(${_tgt} INTERFACE
                                     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/${MODULE_DIR}>
-                                    $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${MODULE_DIR}>)
+                                    $<INSTALL_INTERFACE:${MODULE_DIR}>)
 endforeach()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,9 +123,7 @@ foreach(_tgt IN LISTS LIB_TARGETS)
     target_compile_definitions(${_tgt} PUBLIC "${PUBLIC_FLAGS}")
     target_link_libraries(${_tgt} INTERFACE
         $<$<AND:$<OR:$<Fortran_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:GNU>>,$<NOT:$<CONFIG:Debug>>>:-Wno-lto-type-mismatch>)
-#     target_link_options(${_tgt} INTERFACE -Wno-lto-type-mismatch)
-#         $<$<AND:$<OR:$<Fortran_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:GNU>>,$<NOT:$<CONFIG:Debug>>>:-Wno-lto-type-mismatch>)
-#     #Include Fortran module output directory for build and install interfaces
+    #Include Fortran module output directory for build and install interfaces
     target_include_directories(${_tgt} INTERFACE
                                     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/${MODULE_DIR}>
                                     $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${MODULE_DIR}>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,15 +6,24 @@ cmake_minimum_required( VERSION 3.9 )
 project(bufrlib VERSION 11.3 LANGUAGES C Fortran)
 include(GNUInstallDirs)
 ### Configuration options
-option(BUILD_STATIC_LIBS "Build static library" ON)
-option(BUILD_SHARED_LIBS "Build shared library" OFF)
-option(OPT_IPO "Enable interprocedural optimization if available." ON)
+option(BUILD_STATIC_LIBS "Build static libraries" OFF)
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+option(OPT_IPO "Enable inter-procedural optimization if available." ON)
 
 #Ensure at least one of BUILD_SHARED_LIBS and BUILD_STATIC_LIBS is set
 if(NOT (BUILD_STATIC_LIBS OR BUILD_SHARED_LIBS))
-    message(STATUS "Niether BUILD_STATIC_LIBS nor BUILD_SHARED_LIBS is set.  Defaulting to BUILD_STATIC_LIBS=ON")
-    set(BUILD_STATIC_LIBS ON CACHE BOOL "Build static library" FORCE)
-    set(BUILD_STATIC_LIBS ON)
+    if(OPT_IPO)
+        message(WARNING "Niether BUILD_STATIC_LIBS nor BUILD_SHARED_LIBS is set.  Defaulting to BUILD_SHARED_LIBS=ON")
+        set(BUILD_SHARED_LIBS ON CACHE BOOL "[FORCE ENABLED] Build shared libraries" FORCE)
+        set(BUILD_SHARED_LIBS ON)
+    else()
+        set(BUILD_STATIC_LIBS ON CACHE BOOL "[FORCE ENABLED] Build static libraries" FORCE)
+        set(BUILD_STATIC_LIBS ON)
+    endif()
+endif()
+if(OPT_IPO AND BUILD_STATIC_LIBS)
+    message(WARNING "BUILD_STATIC_LIBS and OPT_IPO are currently incompatible.  Disabling OPT_IPO.")
+    set(OPT_IPO OFF CACHE BOOL "[DISABLED] Conflicts with BUILD_STATIC_LIBS." FORCE)
 endif()
 
 message(STATUS "Option: BUILD_STATIC_LIBS: ${BUILD_STATIC_LIBS}")
@@ -101,12 +110,28 @@ if(BUILD_SHARED_LIBS)
     list(APPEND LIB_TARGETS ${PROJECT_NAME}_shared)
 endif()
 
-#Set common lib target properties
+### Set common lib target properties
+
+#Include Fortran module output directory
+set(MODULE_DIR module/${PROJECT_NAME}/${CMAKE_Fortran_COMPILER_ID}/${CMAKE_Fortran_COMPILER_VERSION})
+set_target_properties(${PROJECT_NAME}_objects PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/${MODULE_DIR})
+install(DIRECTORY ${CMAKE_BINARY_DIR}/${MODULE_DIR}/ DESTINATION ${MODULE_DIR})
+
 set_target_properties(${LIB_TARGETS} PROPERTIES OUTPUT_NAME bufr)
 foreach(_tgt IN LISTS LIB_TARGETS)
     #PUBLIC target_compile_definitions are not correctly propagated from object libraries
     target_compile_definitions(${_tgt} PUBLIC "${PUBLIC_FLAGS}")
+    target_link_libraries(${_tgt} INTERFACE
+        $<$<AND:$<OR:$<Fortran_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:GNU>>,$<NOT:$<CONFIG:Debug>>>:-Wno-lto-type-mismatch>)
+#     target_link_options(${_tgt} INTERFACE -Wno-lto-type-mismatch)
+#         $<$<AND:$<OR:$<Fortran_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:GNU>>,$<NOT:$<CONFIG:Debug>>>:-Wno-lto-type-mismatch>)
+#     #Include Fortran module output directory for build and install interfaces
+    target_include_directories(${_tgt} INTERFACE
+                                    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/${MODULE_DIR}>
+                                    $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${MODULE_DIR}>)
 endforeach()
+
+
 
 ### Install
 install(TARGETS ${LIB_TARGETS} EXPORT ${PROJECT_NAME}Exports

--- a/src/seqsdx.f
+++ b/src/seqsdx.f
@@ -116,7 +116,7 @@ C           using F=1 "regular" (i.e. non-delayed) replication).
             IF(I.EQ.1 .AND. NUMR.LE.0  ) GOTO 903
             IF(I.EQ.1 .AND. NUMR.GT.255) GOTO 904
             IF(I.NE.1 .AND. NUMR.NE.0  ) GOTO 905
-            ATAG = ATAG(2:J-1)
+            ATAG(:J-2) = ATAG(2:J-1)
             IREP = I
             GOTO 1
          ENDIF

--- a/src/seqsdx.f
+++ b/src/seqsdx.f
@@ -116,7 +116,7 @@ C           using F=1 "regular" (i.e. non-delayed) replication).
             IF(I.EQ.1 .AND. NUMR.LE.0  ) GOTO 903
             IF(I.EQ.1 .AND. NUMR.GT.255) GOTO 904
             IF(I.NE.1 .AND. NUMR.NE.0  ) GOTO 905
-            ATAG(:J-2) = ATAG(2:J-1)
+            ATAG(1:J-2) = ATAG(2:J-1)
             IREP = I
             GOTO 1
          ENDIF

--- a/src/stseq.c
+++ b/src/stseq.c
@@ -244,7 +244,7 @@ void stseq( f77int *lun, f77int *irepct, f77int *idn, char nemo[8],
 		    strncpy( &card[16], "0", 1 );
 		    strncpy( &card[30], "0", 1 );
 		    sprintf( &card[33], "%4lu", ( unsigned long ) nbits );
-		    strncpy( &card[40], units, strlen( units ) );
+		    strncpy( &card[40], units, 40 );
 		    elemdx( card, lun, sizeof( card ) );
 		  }
 		  if ( ix == 4 )  {


### PR DESCRIPTION
* Disable LTO with static-libraries.  There are downstream linking issues which I have not been able to resolve easily.
* Add  `-Wno-lto-type-mismatch`  to link interface when not in debug builds for gfortran.
* Build shared libraries by default
* Install modules to `module/${PROJECT_NAME}/${CMAKE_Fortran_COMPILER_ID}/${CMAKE_Fortran_COMPILER_VERSION}`
* Fix warnings in Fortran code
