### PR TITLE
 Merge with NCEPLIBS-bufr.  Rename `bufrlib` -> `bufr`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 
 cmake_minimum_required( VERSION 3.12 )
-project(bufrlib VERSION 11.3 LANGUAGES C Fortran)
+project(bufr VERSION 11.3 LANGUAGES C Fortran)
 include(GNUInstallDirs)
 ### Configuration options
 option(BUILD_STATIC_LIBS "Build static libraries" OFF)
@@ -120,7 +120,7 @@ endif()
 ### Set common lib target properties
 
 #Include Fortran module output directory
-set(MODULE_DIR module/${PROJECT_NAME}/${CMAKE_Fortran_COMPILER_ID}/${CMAKE_Fortran_COMPILER_VERSION})
+set(MODULE_DIR ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/${CMAKE_Fortran_COMPILER_ID}/${CMAKE_Fortran_COMPILER_VERSION})
 set_target_properties(${PROJECT_NAME}_objects PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/${MODULE_DIR})
 install(DIRECTORY ${CMAKE_BINARY_DIR}/${MODULE_DIR}/ DESTINATION ${MODULE_DIR})
 
@@ -154,15 +154,15 @@ include(CMakePackageConfigHelpers)
 
 export(EXPORT ${PROJECT_NAME}Exports NAMESPACE ${PROJECT_NAME}:: FILE ${PROJECT_NAME}-targets.cmake)
 
-set(CONFIG_INSTALL_DESTINATION share/${PROJECT_NAME}/cmake)
+set(CONFIG_INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 
-# bufrlib-config.cmake
+# package-config.cmake
 configure_package_config_file(cmake/PackageConfig.cmake.in ${PROJECT_NAME}-config.cmake
                               INSTALL_DESTINATION ${CONFIG_INSTALL_DESTINATION})
 install(FILES ${CMAKE_BINARY_DIR}/${PROJECT_NAME}-config.cmake 
         DESTINATION ${CONFIG_INSTALL_DESTINATION})
 
-# bufrlib-config-version.cmake
+# package-config-version.cmake
 write_basic_package_version_file(
     ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
     VERSION ${PROJECT_VERSION}
@@ -170,7 +170,7 @@ write_basic_package_version_file(
 install(FILES ${CMAKE_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake 
         DESTINATION ${CONFIG_INSTALL_DESTINATION})
 
-# bufrlib-targets.cmake and bufrlib-targets-<build-type>.cmake
+# package-targets.cmake and package-targets-<build-type>.cmake
 install(EXPORT ${PROJECT_NAME}Exports NAMESPACE ${PROJECT_NAME}::
         FILE ${PROJECT_NAME}-targets.cmake
         DESTINATION ${CONFIG_INSTALL_DESTINATION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,7 @@ endif()
 ### Set common lib target properties
 
 #Include Fortran module output directory
-set(MODULE_DIR ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/${CMAKE_Fortran_COMPILER_ID}/${CMAKE_Fortran_COMPILER_VERSION})
+set(MODULE_DIR ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/module/${CMAKE_Fortran_COMPILER_ID}/${CMAKE_Fortran_COMPILER_VERSION})
 set_target_properties(${PROJECT_NAME}_objects PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/${MODULE_DIR})
 install(DIRECTORY ${CMAKE_BINARY_DIR}/${MODULE_DIR}/ DESTINATION ${MODULE_DIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,6 @@ set(MODULE_DIR ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/${CMAKE_Fortran_COMPILER_
 set_target_properties(${PROJECT_NAME}_objects PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/${MODULE_DIR})
 install(DIRECTORY ${CMAKE_BINARY_DIR}/${MODULE_DIR}/ DESTINATION ${MODULE_DIR})
 
-set_target_properties(${LIB_TARGETS} PROPERTIES OUTPUT_NAME bufr)
 foreach(_tgt IN LISTS LIB_TARGETS)
     #PUBLIC target_compile_definitions are not correctly propagated from object libraries
     target_compile_definitions(${_tgt} PUBLIC "${PUBLIC_DEFS}")

--- a/cmake/PackageConfig.cmake.in
+++ b/cmake/PackageConfig.cmake.in
@@ -45,7 +45,10 @@ else()
     set(@PROJECT_NAME@_FOUND 0)
     set(@PROJECT_NAME@_NOT_FOUND_MESSAGE "Neither BUILD_SHARED_LIBS nor BUILD_STATIC_LIBS was set.  Unable to find any libraries.")
 endif()
+#Aliases for NCEPLIBS-bufr naming compatibility point to default targets
 add_library(@PROJECT_NAME@::@PROJECT_NAME@ ALIAS ${@PROJECT_NAME@_LIBRARIES})
+add_library(@PROJECT_NAME@::@PROJECT_NAME@_4_DA ALIAS ${@PROJECT_NAME@_LIBRARIES})
+
 get_target_property(@PROJECT_NAME@_BUILD_TYPES ${@PROJECT_NAME@_LIBRARIES} IMPORTED_CONFIGURATIONS)
 
 #Export Fortran compiler version and check module compatibility

--- a/cmake/PackageConfig.cmake.in
+++ b/cmake/PackageConfig.cmake.in
@@ -7,10 +7,13 @@
 #  * STATIC - Find static libraries.
 #
 # Output variables set:
+#  * @PROJECT_NAME@_VERSION - Version of install package
 #  * @PROJECT_NAME@_LIBRARIES  - set to static libs if available, shared libs otherwise
-#  * @PROJECT_NAME@_SHARED_LIBRARIES - shared libaries if availible
-#  * @PROJECT_NAME@_STATIC_LIBRARIES - static libaries if availible
+#  * @PROJECT_NAME@_SHARED_LIBRARIES - shared libraries if available
+#  * @PROJECT_NAME@_STATIC_LIBRARIES - static libraries if available
 #  * @PROJECT_NAME@_BUILD_TYPES - build types provided
+#  * @PROJECT_NAME@_MODULES_Fortran_COMPILER_ID - Compiler used to generate Fortran Modules
+#  * @PROJECT_NAME@_MODULES_Fortran_COMPILER_VERSION - Compiler version used to generate Fortran Modules
 #
 # Imported interface targets provided:
 #  * @PROJECT_NAME@::@PROJECT_NAME@_static - static library target
@@ -18,6 +21,9 @@
 
 #Include targets file.  This will create IMPORTED target @PROJECT_NAME@
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
+
+set(@PROJECT_NAME@_VERSION @PROJECT_VERSION@)
+
 set(@PROJECT_NAME@_SHARED_LIBRARIES)
 set(@PROJECT_NAME@_STATIC_LIBRARIES)
 set(@PROJECT_NAME@_SHARED_FOUND 0)
@@ -37,9 +43,22 @@ elseif(@BUILD_SHARED_LIBS@)
     set(@PROJECT_NAME@_SHARED_FOUND 1)
 else()
     set(@PROJECT_NAME@_FOUND 0)
-    set(@PROJECT_NAME@_NOT_FOUND_MESSAGE "Neither BUILD_SHARED_LIBS nor BUILD_STATIC_LIBS was set.  Unable to find any libararies.")
+    set(@PROJECT_NAME@_NOT_FOUND_MESSAGE "Neither BUILD_SHARED_LIBS nor BUILD_STATIC_LIBS was set.  Unable to find any libraries.")
 endif()
-
+add_library(@PROJECT_NAME@::@PROJECT_NAME@ ALIAS ${@PROJECT_NAME@_LIBRARIES})
 get_target_property(@PROJECT_NAME@_BUILD_TYPES ${@PROJECT_NAME@_LIBRARIES} IMPORTED_CONFIGURATIONS)
 
+#Export Fortran compiler version and check module compatibility
+set(@PROJECT_NAME@_MODULES_Fortran_COMPILER_ID @CMAKE_Fortran_COMPILER_ID@)
+set(@PROJECT_NAME@_MODULES_Fortran_COMPILER_VERSION @CMAKE_Fortran_COMPILER_VERSION@)
+if(NOT @PROJECT_NAME@_MODULES_Fortran_COMPILER_ID STREQUAL CMAKE_Fortran_COMPILER_ID
+   OR NOT @PROJECT_NAME@_MODULES_Fortran_COMPILER_VERSION VERSION_EQUAL CMAKE_Fortran_COMPILER_VERSION)
+    message(SEND_ERROR "Package @PROJECT_NAME@ provides Fortran modules built with "
+            "${@PROJECT_NAME@_MODULES_Fortran_COMPILER_ID}-${@PROJECT_NAME@_MODULES_Fortran_COMPILER_VERSION} "
+            "but this build for ${PROJECT_NAME} uses incompatible compiler ${CMAKE_Fortran_COMPILER_ID}-${CMAKE_Fortran_COMPILER_VERSION}")
+endif()
+
 check_required_components("@PROJECT_NAME@")
+
+get_target_property(location ${@PROJECT_NAME@_LIBRARIES} LOCATION)
+message(STATUS "Found @PROJECT_NAME@: ${location} (found version \"@PROJECT_VERSION@\")")

--- a/src/bufrlib.h
+++ b/src/bufrlib.h
@@ -24,6 +24,13 @@
 #endif
 
 /*
+** The following values must be identically defined in source file
+** bufrlib.prm
+*/
+#define MAXNC 600
+#define MXNAF 3
+
+/*
 ** On certain operating systems, the FORTRAN compiler appends an underscore
 ** to subprogram names in its object namespace.  Therefore, on such systems,
 ** a matching underscore must be appended to any C language references to

--- a/src/closbf.F
+++ b/src/closbf.F
@@ -54,10 +54,19 @@ C$$$
       USE MODA_NULBFR
 
       INCLUDE 'bufrlib.prm'
+      CHARACTER*128 ERRSTR
 
 C-----------------------------------------------------------------------
 C-----------------------------------------------------------------------
-
+#ifdef DYNAMIC_ALLOCATION
+      IF ( .NOT. ALLOCATED(NULL) ) THEN
+        CALL ERRWRT('++++++++++++++++++++WARNING++++++++++++++++++++++')
+        ERRSTR = 'BUFRLIB: CLOSBF CALLED BEFORE OPENBF'
+        CALL ERRWRT(ERRSTR)
+        CALL ERRWRT('++++++++++++++++++++WARNING++++++++++++++++++++++')
+        RETURN
+      ENDIF
+#endif
       CALL STATUS(LUNIT,LUN,IL,IM)
       IF(IL.GT.0 .AND. IM.NE.0) CALL CLOSMG(LUNIT)
       IF(IL.NE.0 .AND. NULL(LUN).EQ.0) CALL CLOSFB(LUN)


### PR DESCRIPTION
In order to match as closely as possible the package config for the new NCEPLIBS-bufr CMake, this PR changes the package name from `bufrlib`->`bufr`.  Also
 * Use GNUInstallDirs locations for all installs (move modules under CMAKE_INSTALL_LIBDIR)
 * Improved PackageConfig.cmake will export version information, check Fortran version compatability, and print an informational message when found
 * Add `bufr::bufr` and `bufr::bufr_4_DA` target alias which will point to the shared bufr library if available or the static otherwise.  For now we only build the 4_DA kind, as that is all the JEDI packages currently require.

When compared with the NCEPLIBS-bufr, this build system currently has several advatantages:
1. Installs both shared and static libraries (configurable with options and presented as separate target names)
2. Install directories are all under standard GNU locations, making this package portable to systems which don't allow installation under non-standard directories.
3. User CFLAGS and FFLAGS are not overridden by hardcoded defaults.  This allows users to customize flags via CMake toolchains or environment variables.
4. Modules are not installed under include directory, but protected in a per-compiler-version subdirectory and the PackageConfig checks for compatible Fortran before allowing linking.
5. Support for gfortran-10+
6. Support for interproceedural optimization